### PR TITLE
feat(did): IdentityHub-based DidDocumentServiceClient for DID self-registration

### DIFF
--- a/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
@@ -264,6 +264,18 @@ spec:
               value: "false"
             - name: "TX_EDC_DID_SERVICE_SELF_REGISTRATION_ID"
               value: {{ .Values.iatp.didService.selfRegistration.id | quote }}
+            {{- if .Values.iatp.didService.identityHub.apiUrl }}
+            - name: "TX_EDC_IH_API_URL"
+              value: {{ .Values.iatp.didService.identityHub.apiUrl | quote }}
+            {{- end }}
+            {{- if .Values.iatp.didService.identityHub.apiKey }}
+            - name: "TX_EDC_IH_API_KEY"
+              value: {{ .Values.iatp.didService.identityHub.apiKey | quote }}
+            {{- end }}
+            {{- if .Values.iatp.didService.identityHub.participantContextId }}
+            - name: "TX_EDC_IH_PARTICIPANT_CONTEXT_ID"
+              value: {{ .Values.iatp.didService.identityHub.participantContextId | quote }}
+            {{- end }}
             - name: "TX_EDC_DCP_CACHE_ENABLED"
               value: {{ .Values.iatp.cache.enabled | quote }}
             - name: "TX_EDC_DCP_CACHE_VALIDITY_SECONDS"

--- a/charts/tractusx-connector-memory/values.yaml
+++ b/charts/tractusx-connector-memory/values.yaml
@@ -65,6 +65,13 @@ iatp:
       enabled: false
       # -- Unique id of connector to be used for register / unregister service inside did document (must be valid URI)
       id: "did:web:changeme"
+    identityHub:
+      # -- IdentityHub Identity API base URL. Required when using IdentityHub wallets (not DIM) for DID self-registration.
+      apiUrl:
+      # -- API key for IdentityHub Identity API authentication
+      apiKey:
+      # -- IdentityHub participant context ID (short name, e.g. 'provider')
+      participantContextId:
 
   # - Configures the Verifiable Presentation Ccache
   cache:

--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -262,6 +262,18 @@ spec:
               value: {{ and (eq (int .Values.controlplane.replicaCount) 1) (not .Values.controlplane.autoscaling.enabled) | quote }}
             - name: "TX_EDC_DID_SERVICE_SELF_REGISTRATION_ID"
               value: {{ .Values.iatp.didService.selfRegistration.id | quote }}
+            {{- if .Values.iatp.didService.identityHub.apiUrl }}
+            - name: "TX_EDC_IH_API_URL"
+              value: {{ .Values.iatp.didService.identityHub.apiUrl | quote }}
+            {{- end }}
+            {{- if .Values.iatp.didService.identityHub.apiKey }}
+            - name: "TX_EDC_IH_API_KEY"
+              value: {{ .Values.iatp.didService.identityHub.apiKey | quote }}
+            {{- end }}
+            {{- if .Values.iatp.didService.identityHub.participantContextId }}
+            - name: "TX_EDC_IH_PARTICIPANT_CONTEXT_ID"
+              value: {{ .Values.iatp.didService.identityHub.participantContextId | quote }}
+            {{- end }}
             - name: "TX_EDC_DCP_CACHE_ENABLED"
               value: {{ .Values.iatp.cache.enabled | quote }}
             - name: "TX_EDC_DCP_CACHE_VALIDITY_SECONDS"

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -72,6 +72,13 @@ iatp:
       enabled: false
       # -- Unique id of connector to be used for register / unregister service inside did document (must be valid URI)
       id: "did:web:changeme"
+    identityHub:
+      # -- IdentityHub Identity API base URL. Required when using IdentityHub wallets (not DIM) for DID self-registration.
+      apiUrl:
+      # -- API key for IdentityHub Identity API authentication
+      apiKey:
+      # -- IdentityHub participant context ID (short name, e.g. 'provider')
+      participantContextId:
   # - Configures the Verifiable Presentation cache
   cache:
     # -- Whether the Verifiable Presentation cache is enabled

--- a/deployment/local/PRODUCTION_DEPLOYMENT_GUIDE.md
+++ b/deployment/local/PRODUCTION_DEPLOYMENT_GUIDE.md
@@ -671,6 +671,12 @@ This table maps every local config shortcut to its production equivalent:
 | `edc.core.monitor.level` | `DEBUG` | `INFO` | CP, DP |
 | `tx.edc.postgresql.migration.enabled` | `true` | `false` (run in CI/CD) | CP |
 | `tx.edc.dataplane.token.refresh.endpoint` | `http://provider-dp:8081/api/public/token` | `https://dataplane.company.com/api/public/token` | DP |
+| `tx.edc.did.service.self.registration.enabled` | `true` | `true` | CP |
+| `tx.edc.did.service.self.registration.id` | `dsp-endpoint` | `dsp-endpoint` (or custom URI) | CP |
+| `tx.edc.did.service.self.deregistration.enabled` | `true` | `false` (see scaling note) | CP |
+| `tx.edc.ih.api.url` | `http://provider-ih:15151/api/identity` | `https://identityhub.company.com/api/identity` (or cluster-internal) | CP |
+| `tx.edc.ih.api.key` | `c3VwZXItdXNlcg==.superuserkey` | Strong random key from Vault | CP |
+| `tx.edc.ih.participant.context.id` | `provider` | Company participant context ID | CP |
 
 ---
 
@@ -706,6 +712,9 @@ Use this checklist before going live:
 - [ ] MembershipCredential, BpnCredential, DataExchangeGovernanceCredential issued
 - [ ] Trusted issuer DID configured correctly
 - [ ] `edc.iam.did.web.use.https=true` confirmed in all configs
+- [ ] DID self-registration enabled (`tx.edc.did.service.self.registration.enabled=true`)
+- [ ] DID self-deregistration disabled in HA (`tx.edc.did.service.self.deregistration.enabled=false`) — see scaling note in decision record
+- [ ] IdentityHub API URL and API key configured for self-registration client
 
 ### Connectivity
 - [ ] DSP endpoint (`/api/v1/dsp/*`) reachable from trading partners
@@ -733,6 +742,7 @@ Use this checklist before going live:
 ### Validation
 - [ ] Health check endpoints responding on all components
 - [ ] DID resolution working end-to-end (curl the DID URL)
+- [ ] DID Document contains `DataService` entry with correct DSP endpoint (auto-registered on startup)
 - [ ] STS token issuance working
 - [ ] Catalog request succeeds with a known trading partner
 - [ ] Contract negotiation succeeds
@@ -748,7 +758,7 @@ The local deployment uses three property files per company stack:
 
 | File | Component | Key Sections |
 |------|-----------|-------------|
-| `provider-cp.properties` | Control Plane | Identity, endpoints, STS, BDRS, datasource, vault, proxy keys, policy |
+| `provider-cp.properties` | Control Plane | Identity, endpoints, STS, BDRS, datasource, vault, proxy keys, policy, DID self-registration (IH client settings) |
 | `provider-dp.properties` | Data Plane | Endpoints, STS, datasource, vault, public API URL, proxy keys, token expiry |
 | `provider-ih.properties` | IdentityHub | Endpoints, STS settings, super-user, vault, datasource (12 named stores) |
 

--- a/deployment/local/README.md
+++ b/deployment/local/README.md
@@ -449,6 +449,27 @@ Each participant (provider, consumer) receives 3 VCs from the issuer:
 | `BpnCredential` | Binds BPN to DID identity |
 | `DataExchangeGovernanceCredential` | Authorizes data exchange under framework agreements |
 
+### DID Service Self-Registration
+
+Each control plane automatically registers its DSP endpoint as a `DataService` entry in its
+DID Document via the IdentityHub Identity API on startup, and deregisters on shutdown.
+This removes the need for bootstrap Step 8's manual `curl` calls.
+
+**Key configuration (on each CP):**
+
+| Property | Example Value | Description |
+|----------|--------------|-------------|
+| `tx.edc.did.service.self.registration.enabled` | `true` | Enables automatic DSP endpoint registration |
+| `tx.edc.did.service.self.registration.id` | `dsp-endpoint` | Service entry ID in the DID Document |
+| `tx.edc.did.service.self.deregistration.enabled` | `true` | Clean up on shutdown |
+| `tx.edc.ih.api.url` | `http://provider-ih:15151/api/identity` | IdentityHub Identity API URL |
+| `tx.edc.ih.api.key` | `c3VwZXItdXNlcg==.superuserkey` | IdentityHub API key |
+| `tx.edc.ih.participant.context.id` | `provider` | Participant context ID (short name) |
+
+See the [IdentityHub Client README](../../edc-extensions/did-document/did-document-service-identityhub/README.md)
+and the [Self-Registration README](../../edc-extensions/did-document/did-document-service-self-registration/README.md)
+for full details.
+
 ---
 
 ## API Keys
@@ -594,6 +615,7 @@ These don't expose API endpoints but modify runtime behavior:
 | `validators` | Blocks empty asset selectors in contract definitions |
 | `agreements-bpns` | Stores BPNL associations on negotiation events |
 | `dcp/` | W3C VC caching + DIM integration |
+| `did-document/` | DID Document self-registration + wallet clients (IdentityHub, DIM) |
 
 ---
 
@@ -645,6 +667,7 @@ curl -s http://localhost:8581/api/management/bpn-directory \
 | Transfer stuck at REQUESTED | Data plane not reachable | Check `edc.hostname` on DP config |
 | EDR token invalid | Transfer proxy key format | Must be EC P-256 JWK in Vault |
 | `IRI_CONFUSED_WITH_PREFIX` | Compact IRI in leftOperand | Use full IRI: `https://w3id.org/catenax/2025/9/policy/...` |
+| DID Document missing DataService | Self-registration not configured | Verify `tx.edc.ih.api.url`, `tx.edc.ih.api.key`, and `tx.edc.ih.participant.context.id` on CP |
 
 ### Clean up
 
@@ -684,7 +707,7 @@ deployment/local/
 ├── README.md                      ← This file
 ├── PRODUCTION_DEPLOYMENT_GUIDE.md ← What to change for production (infra team reference)
 ├── Dockerfile                     ← Multi-stage Docker build for CP and DP
-├── docker-compose.yaml            ← 11 containers (provider, consumer, BDRS)
+├── docker-compose.yaml            ← 14 containers (provider, consumer, BDRS)
 ├── config/
 │   ├── provider-cp.properties     ← Provider Control Plane config
 │   ├── provider-dp.properties     ← Provider Data Plane config

--- a/deployment/local/config/consumer-cp.properties
+++ b/deployment/local/config/consumer-cp.properties
@@ -72,6 +72,18 @@ tx.edc.postgresql.migration.enabled=true
 tx.edc.postgresql.migration.schema=public
 
 ############################
+# DID SELF-REGISTRATION     #
+############################
+# IdentityHub-based DID document service client
+tx.edc.ih.api.url=http://consumer-ih:15151/api/identity
+tx.edc.ih.api.key=c3VwZXItdXNlcg==.superuserkey
+tx.edc.ih.participant.context.id=consumer
+# Auto-register DataService endpoint in DID document on startup
+tx.edc.did.service.self.registration.enabled=true
+tx.edc.did.service.self.registration.id=dsp-endpoint
+tx.edc.did.service.self.deregistration.enabled=true
+
+############################
 # VAULT                    #
 ############################
 edc.vault.hashicorp.url=http://consumer-vault:8200

--- a/deployment/local/config/provider-cp.properties
+++ b/deployment/local/config/provider-cp.properties
@@ -79,6 +79,18 @@ tx.edc.postgresql.migration.enabled=true
 tx.edc.postgresql.migration.schema=public
 
 ############################
+# DID SELF-REGISTRATION     #
+############################
+# IdentityHub-based DID document service client
+tx.edc.ih.api.url=http://provider-ih:15151/api/identity
+tx.edc.ih.api.key=c3VwZXItdXNlcg==.superuserkey
+tx.edc.ih.participant.context.id=provider
+# Auto-register DataService endpoint in DID document on startup
+tx.edc.did.service.self.registration.enabled=true
+tx.edc.did.service.self.registration.id=dsp-endpoint
+tx.edc.did.service.self.deregistration.enabled=true
+
+############################
 # VAULT                    #
 ############################
 edc.vault.hashicorp.url=http://provider-vault:8200

--- a/deployment/local/scripts/bootstrap.sh
+++ b/deployment/local/scripts/bootstrap.sh
@@ -371,11 +371,11 @@ docker exec provider-postgres psql -U provider -d provider -c "
   UPDATE keypair_resource SET key_id = '${PROVIDER_DID}#provider-key'
     WHERE key_id = 'provider-key';
   UPDATE did_resources SET did_document = jsonb_set(
-    did_document, '{verificationMethod,0,id}', '\"${PROVIDER_DID}#provider-key\"'
-  ) WHERE did IS NOT NULL;
+    did_document::jsonb, '{verificationMethod,0,id}', '\"${PROVIDER_DID}#provider-key\"'
+  )::json WHERE did = '${PROVIDER_DID}';
   UPDATE did_resources SET did_document = jsonb_set(
-    did_document, '{verificationMethod,0,publicKeyJwk,kid}', '\"${PROVIDER_DID}#provider-key\"'
-  ) WHERE did IS NOT NULL;
+    did_document::jsonb, '{verificationMethod,0,publicKeyJwk,kid}', '\"${PROVIDER_DID}#provider-key\"'
+  )::json WHERE did = '${PROVIDER_DID}';
 " > /dev/null 2>&1 && echo "  Provider key IDs fixed." || echo "  WARNING: Provider key fix failed."
 
 echo "  Fixing consumer key IDs in consumer-postgres..."
@@ -383,11 +383,11 @@ docker exec consumer-postgres psql -U consumer -d consumer -c "
   UPDATE keypair_resource SET key_id = '${CONSUMER_DID}#consumer-key'
     WHERE key_id = 'consumer-key';
   UPDATE did_resources SET did_document = jsonb_set(
-    did_document, '{verificationMethod,0,id}', '\"${CONSUMER_DID}#consumer-key\"'
-  ) WHERE did IS NOT NULL;
+    did_document::jsonb, '{verificationMethod,0,id}', '\"${CONSUMER_DID}#consumer-key\"'
+  )::json WHERE did = '${CONSUMER_DID}';
   UPDATE did_resources SET did_document = jsonb_set(
-    did_document, '{verificationMethod,0,publicKeyJwk,kid}', '\"${CONSUMER_DID}#consumer-key\"'
-  ) WHERE did IS NOT NULL;
+    did_document::jsonb, '{verificationMethod,0,publicKeyJwk,kid}', '\"${CONSUMER_DID}#consumer-key\"'
+  )::json WHERE did = '${CONSUMER_DID}';
 " > /dev/null 2>&1 && echo "  Consumer key IDs fixed." || echo "  WARNING: Consumer key fix failed."
 
 echo "  Fixing issuer key IDs in issuer-postgres..."
@@ -395,11 +395,11 @@ docker exec issuer-postgres psql -U postgres -d issuerservice -c "
   UPDATE keypair_resource SET key_id = '${ISSUER_DID}#issuer-key'
     WHERE key_id = 'issuer-key';
   UPDATE did_resources SET did_document = jsonb_set(
-    did_document, '{verificationMethod,0,id}', '\"${ISSUER_DID}#issuer-key\"'
-  ) WHERE did IS NOT NULL;
+    did_document::jsonb, '{verificationMethod,0,id}', '\"${ISSUER_DID}#issuer-key\"'
+  )::json WHERE did = '${ISSUER_DID}';
   UPDATE did_resources SET did_document = jsonb_set(
-    did_document, '{verificationMethod,0,publicKeyJwk,kid}', '\"${ISSUER_DID}#issuer-key\"'
-  ) WHERE did IS NOT NULL;
+    did_document::jsonb, '{verificationMethod,0,publicKeyJwk,kid}', '\"${ISSUER_DID}#issuer-key\"'
+  )::json WHERE did = '${ISSUER_DID}';
 " > /dev/null 2>&1 && echo "  Issuer key IDs fixed." || echo "  WARNING: Issuer key fix failed."
 echo ""
 
@@ -446,9 +446,9 @@ curl -sf -X POST "${CONSUMER_IH_IDENTITY}/v1alpha/participants/${CONSUMER_B64}/d
 echo "  Adding IssuerService endpoint to issuer DID..."
 docker exec issuer-postgres psql -U postgres -d issuerservice -c "
   UPDATE did_resources SET did_document = jsonb_set(
-    did_document, '{service}',
-    COALESCE(did_document->'service', '[]'::jsonb) || '[{\"id\":\"issuer-service\",\"type\":\"IssuerService\",\"serviceEndpoint\":\"http://issuerservice:13132/api/issuance/v1alpha/participants/${ISSUER_B64}\"}]'::jsonb
-  ) WHERE did IS NOT NULL;
+    did_document::jsonb, '{service}',
+    COALESCE(did_document::jsonb->'service', '[]'::jsonb) || '[{\"id\":\"issuer-service\",\"type\":\"IssuerService\",\"serviceEndpoint\":\"http://issuerservice:13132/api/issuance/v1alpha/participants/${ISSUER_B64}\"}]'::jsonb
+  )::json WHERE did = '${ISSUER_DID}';
 " > /dev/null 2>&1 && echo "  Issuer IssuerService endpoint added." || echo "  WARNING: Issuer IssuerService endpoint failed."
 echo ""
 
@@ -617,6 +617,15 @@ echo ""
 # ========================================
 echo "Step 10: Requesting credentials via DCP..."
 
+# Retrieve credential definition IDs from issuer DB (POST returns empty body)
+MEMBERSHIP_DEF_ID=$(docker exec issuer-postgres psql -U postgres -d issuerservice -tAc \
+    "SELECT id FROM credential_definitions WHERE credential_type='MembershipCredential' LIMIT 1;")
+BPN_DEF_ID=$(docker exec issuer-postgres psql -U postgres -d issuerservice -tAc \
+    "SELECT id FROM credential_definitions WHERE credential_type='BpnCredential' LIMIT 1;")
+DEG_DEF_ID=$(docker exec issuer-postgres psql -U postgres -d issuerservice -tAc \
+    "SELECT id FROM credential_definitions WHERE credential_type='DataExchangeGovernanceCredential' LIMIT 1;")
+echo "  Credential definition IDs: Membership=${MEMBERSHIP_DEF_ID}, BPN=${BPN_DEF_ID}, DEG=${DEG_DEF_ID}"
+
 echo "  Requesting MembershipCredential for provider..."
 curl -sf -X POST "${PROVIDER_IH_IDENTITY}/v1alpha/participants/${PROVIDER_B64}/credentials/request" \
     -H "x-api-key: ${SUPERUSER_KEY}" \
@@ -626,7 +635,8 @@ curl -sf -X POST "${PROVIDER_IH_IDENTITY}/v1alpha/participants/${PROVIDER_B64}/c
       \"holderPid\": \"provider-membership-request\",
       \"credentials\": [{
         \"format\": \"VC1_0_JWT\",
-        \"credentialType\": \"MembershipCredential\"
+        \"type\": \"MembershipCredential\",
+        \"id\": \"${MEMBERSHIP_DEF_ID}\"
       }]
     }" > /dev/null 2>&1 && echo "  Provider MembershipCredential requested." || echo "  WARNING: Provider MembershipCredential request failed."
 
@@ -639,7 +649,8 @@ curl -sf -X POST "${CONSUMER_IH_IDENTITY}/v1alpha/participants/${CONSUMER_B64}/c
       \"holderPid\": \"consumer-membership-request\",
       \"credentials\": [{
         \"format\": \"VC1_0_JWT\",
-        \"credentialType\": \"MembershipCredential\"
+        \"type\": \"MembershipCredential\",
+        \"id\": \"${MEMBERSHIP_DEF_ID}\"
       }]
     }" > /dev/null 2>&1 && echo "  Consumer MembershipCredential requested." || echo "  WARNING: Consumer MembershipCredential request failed."
 
@@ -652,7 +663,8 @@ curl -sf -X POST "${PROVIDER_IH_IDENTITY}/v1alpha/participants/${PROVIDER_B64}/c
       \"holderPid\": \"provider-bpn-request\",
       \"credentials\": [{
         \"format\": \"VC1_0_JWT\",
-        \"credentialType\": \"BpnCredential\"
+        \"type\": \"BpnCredential\",
+        \"id\": \"${BPN_DEF_ID}\"
       }]
     }" > /dev/null 2>&1 && echo "  Provider BpnCredential requested." || echo "  WARNING: Provider BpnCredential request failed."
 
@@ -665,7 +677,8 @@ curl -sf -X POST "${CONSUMER_IH_IDENTITY}/v1alpha/participants/${CONSUMER_B64}/c
       \"holderPid\": \"consumer-bpn-request\",
       \"credentials\": [{
         \"format\": \"VC1_0_JWT\",
-        \"credentialType\": \"BpnCredential\"
+        \"type\": \"BpnCredential\",
+        \"id\": \"${BPN_DEF_ID}\"
       }]
     }" > /dev/null 2>&1 && echo "  Consumer BpnCredential requested." || echo "  WARNING: Consumer BpnCredential request failed."
 
@@ -678,7 +691,8 @@ curl -sf -X POST "${PROVIDER_IH_IDENTITY}/v1alpha/participants/${PROVIDER_B64}/c
       \"holderPid\": \"provider-deg-request\",
       \"credentials\": [{
         \"format\": \"VC1_0_JWT\",
-        \"credentialType\": \"DataExchangeGovernanceCredential\"
+        \"type\": \"DataExchangeGovernanceCredential\",
+        \"id\": \"${DEG_DEF_ID}\"
       }]
     }" > /dev/null 2>&1 && echo "  Provider DataExchangeGovernanceCredential requested." || echo "  WARNING: Provider DataExchangeGovernanceCredential request failed."
 
@@ -691,7 +705,8 @@ curl -sf -X POST "${CONSUMER_IH_IDENTITY}/v1alpha/participants/${CONSUMER_B64}/c
       \"holderPid\": \"consumer-deg-request\",
       \"credentials\": [{
         \"format\": \"VC1_0_JWT\",
-        \"credentialType\": \"DataExchangeGovernanceCredential\"
+        \"type\": \"DataExchangeGovernanceCredential\",
+        \"id\": \"${DEG_DEF_ID}\"
       }]
     }" > /dev/null 2>&1 && echo "  Consumer DataExchangeGovernanceCredential requested." || echo "  WARNING: Consumer DataExchangeGovernanceCredential request failed."
 

--- a/docs/development/decision-records/2025-11-27-did-service-registration/README.md
+++ b/docs/development/decision-records/2025-11-27-did-service-registration/README.md
@@ -24,6 +24,7 @@ to avoid creating duplicate `service` entries and manage itself.
 2. Create a new SPI including an interface that represents the feature in an abstract manner.
 3. Add an extension that will implement the lifecycle management logic.
 4. Another extension implements the SPI's interface as client for [SAP DIV's write endpoint to the did document](https://api.sap.com/api/DIV/path/CompanyIdentityV2HttpController_updateCompanyIdentity_v2.0.0).
+5. An additional extension implements the SPI's interface as client for the **IdentityHub Identity API** (`/v1alpha/participants/{id}/dids/{did}/endpoints`), enabling self-registration for deployments using Eclipse Tractus-X IdentityHub as their wallet.
 
 The lifecycle management logic is designed to ensure functional correctness while limiting outbound HTTP traffic on 
 startup. It shall behave acoording to the following diagram:

--- a/docs/development/local-dcp-issues-and-fixes.md
+++ b/docs/development/local-dcp-issues-and-fixes.md
@@ -554,3 +554,32 @@ already-bootstrapped deployment.
 | `odrl:assigner` (negotiation) | Provider BPN, not DID | DSP v0.8 BPN extraction |
 | `odrl:action` (negotiation) | `{"@id": "odrl:use"}` | Policy comparison requires full IRI |
 | `odrl:leftOperand` (negotiation) | Full IRI with `{"@id": "..."}` | Avoids `IRI_CONFUSED_WITH_PREFIX` |
+| `tx.edc.ih.api.url` (CP) | IdentityHub Identity API URL (e.g., `http://provider-ih:15151/api/identity`) | DID self-registration via IdentityHub |
+| `tx.edc.ih.api.key` (CP) | IdentityHub API key | Authentication for DID self-registration |
+| `tx.edc.ih.participant.context.id` (CP) | Short participant name (e.g., `provider`) | IdentityHub participant context lookup |
+| `tx.edc.did.service.self.registration.enabled` (CP) | `true` | Enables automatic DSP endpoint registration in DID Document |
+
+---
+
+## Update: DID Service Self-Registration via IdentityHub
+
+Bootstrap Step 8 ("Add service endpoints to DID documents") was originally a manual `curl` call to the IdentityHub
+Identity API. With the addition of the `did-document-service-identityhub` module (branch `feature/did-document-service-ih`),
+this step is now **automated at connector startup**.
+
+When self-registration is enabled, each control plane registers its DSP endpoint as a `DataService` entry in its
+DID Document via the IdentityHub Identity API on startup, and deregisters on shutdown.
+
+**Configuration required on each CP:**
+
+```properties
+tx.edc.did.service.self.registration.enabled=true
+tx.edc.did.service.self.registration.id=dsp-endpoint
+tx.edc.did.service.self.deregistration.enabled=true
+tx.edc.ih.api.url=http://provider-ih:15151/api/identity
+tx.edc.ih.api.key=c3VwZXItdXNlcg==.superuserkey
+tx.edc.ih.participant.context.id=provider
+```
+
+See the [IdentityHub Client README](../../edc-extensions/did-document/did-document-service-identityhub/README.md)
+for full details.

--- a/edc-controlplane/edc-controlplane-base/build.gradle.kts
+++ b/edc-controlplane/edc-controlplane-base/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation(project(":edc-extensions:event-subscriber"))
     implementation(project(":edc-extensions:did-document:did-document-service-self-registration"))
     implementation(project(":edc-extensions:did-document:did-document-service-dim"))
+    implementation(project(":edc-extensions:did-document:did-document-service-identityhub"))
 
     runtimeOnly(libs.bundles.edc.monitoring)
     runtimeOnly(libs.edc.aws.validator.data.address.s3)

--- a/edc-extensions/did-document/did-document-service-identityhub/README.md
+++ b/edc-extensions/did-document/did-document-service-identityhub/README.md
@@ -1,0 +1,83 @@
+# did-document-service-identityhub
+
+## Overview
+This extension provides a client for managing DID Document Service entries using the **IdentityHub Identity API**.
+It implements the `DidDocumentServiceClient` SPI, enabling the `did-document-service-self-registration` extension
+to automatically register and deregister DSP endpoints in DID Documents for deployments that use
+[Eclipse Tractus-X IdentityHub](https://github.com/eclipse-tractusx/tractusx-identityhub) as their wallet.
+
+This is the alternative to the `did-document-service-dim` module, which targets SAP DIM wallets.
+
+## API Details
+
+### 1. Add DID Document Service (Create)
+- **Endpoint:** `POST {identityApiUrl}/v1alpha/participants/{participantB64}/dids/{didB64}/endpoints?autoPublish=true`
+- **Auth:** `x-api-key` header
+- **Path parameters:** Standard Base64 encoding of participant context ID and DID
+- **Description:** Creates a service entry in the DID Document. Returns 409 if the entry already exists (treated as success for idempotency).
+- **Sample Request Body:**
+
+```json
+{
+  "id": "dsp-endpoint",
+  "type": "DataService",
+  "serviceEndpoint": "https://connector.company.com/edc/.well-known/dspace-version"
+}
+```
+
+### 2. Delete DID Document Service
+- **Endpoint:** `DELETE {identityApiUrl}/v1alpha/participants/{participantB64}/dids/{didB64}/endpoints/{serviceId}?autoPublish=true`
+- **Auth:** `x-api-key` header
+- **Description:** Removes a service entry from the DID Document. Returns 404 if the entry does not exist (treated as success for idempotency).
+
+### Update Behavior
+The `update()` method performs a delete-then-create sequence, ensuring the endpoint URL is always current.
+Both 404 on delete and 409 on create are tolerated for idempotent behavior.
+
+## Configuration
+
+| Property | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `tx.edc.ih.api.url` | Yes | — | IdentityHub Identity API base URL (e.g., `http://provider-ih:15151/api/identity`) |
+| `tx.edc.ih.api.key` | Yes | — | API key for IdentityHub Identity API authentication |
+| `tx.edc.ih.participant.context.id` | Yes | — | IdentityHub participant context ID (short name, e.g., `provider`) |
+| `edc.iam.issuer.id` | Yes | — | The DID of this connector's participant (e.g., `did:web:provider-ih:provider`) |
+
+> **Note:** If `tx.edc.ih.api.url` is not configured, the extension logs an info message and does not register a client,
+> allowing other implementations (e.g., the DIM client) to be used instead.
+
+## Usage with Self-Registration
+
+This module is designed to work with the `did-document-service-self-registration` extension.
+Include both modules in your control plane build and configure the self-registration properties:
+
+```properties
+# Enable self-registration
+tx.edc.did.service.self.registration.enabled=true
+tx.edc.did.service.self.registration.id=dsp-endpoint
+tx.edc.did.service.self.deregistration.enabled=true
+
+# IdentityHub client settings
+tx.edc.ih.api.url=http://provider-ih:15151/api/identity
+tx.edc.ih.api.key=c3VwZXItdXNlcg==.superuserkey
+tx.edc.ih.participant.context.id=provider
+```
+
+## Comparison with DIM Client
+
+| Aspect | IdentityHub Client (this module) | DIM Client |
+|--------|----------------------------------|------------|
+| Wallet | Eclipse Tractus-X IdentityHub | SAP DIM (Decentralized Identity Management) |
+| API | REST (POST/DELETE per endpoint) | PATCH (batch add/remove services + status update) |
+| Auth | `x-api-key` header | OAuth2 token |
+| Idempotency | Tolerates 409 on create, 404 on delete | Handled by DIM API |
+| Use case | Local/dev deployments, open-source wallets | SAP-managed production environments |
+
+## Module Dependencies
+
+```kotlin
+implementation(project(":spi:did-document-service-spi"))
+implementation(libs.edc.runtime.metamodel)
+implementation(libs.edc.spi.identity.did)
+implementation(libs.edc.spi.http)
+```

--- a/edc-extensions/did-document/did-document-service-identityhub/build.gradle.kts
+++ b/edc-extensions/did-document/did-document-service-identityhub/build.gradle.kts
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+dependencies {
+    implementation(project(":spi:did-document-service-spi"))
+    implementation(libs.edc.runtime.metamodel)
+    implementation(libs.edc.spi.identity.did)
+    implementation(libs.edc.spi.http)
+
+    testImplementation(libs.edc.junit)
+}

--- a/edc-extensions/did-document/did-document-service-identityhub/src/main/java/org/eclipse/tractusx/edc/did/document/service/identityhub/DidDocumentServiceIdentityHubClient.java
+++ b/edc-extensions/did-document/did-document-service-identityhub/src/main/java/org/eclipse/tractusx/edc/did/document/service/identityhub/DidDocumentServiceIdentityHubClient.java
@@ -19,19 +19,20 @@
 
 package org.eclipse.tractusx.edc.did.document.service.identityhub;
 
-import okhttp3.MediaType;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.iam.did.spi.document.Service;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.tractusx.edc.spi.did.document.service.DidDocumentServiceClient;
 
-import java.io.IOException;
-import java.util.Base64;
-import java.util.List;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 /**
  * Implementation of {@link DidDocumentServiceClient} that interacts with an Eclipse Tractus-X

--- a/edc-extensions/did-document/did-document-service-identityhub/src/main/java/org/eclipse/tractusx/edc/did/document/service/identityhub/DidDocumentServiceIdentityHubClient.java
+++ b/edc-extensions/did-document/did-document-service-identityhub/src/main/java/org/eclipse/tractusx/edc/did/document/service/identityhub/DidDocumentServiceIdentityHubClient.java
@@ -1,0 +1,167 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.did.document.service.identityhub;
+
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.iam.did.spi.document.Service;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.tractusx.edc.spi.did.document.service.DidDocumentServiceClient;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Implementation of {@link DidDocumentServiceClient} that interacts with an Eclipse Tractus-X
+ * IdentityHub to manage service entries in a DID Document.
+ * <p>
+ * Unlike the DIM-based implementation, IdentityHub provides a simple REST API:
+ * <ul>
+ *   <li>POST to add a service endpoint (with {@code autoPublish=true})</li>
+ *   <li>DELETE to remove a service endpoint by ID</li>
+ * </ul>
+ * <p>
+ * The API path is:
+ * {@code /v1alpha/participants/{participantB64}/dids/{didB64}/endpoints}
+ */
+public class DidDocumentServiceIdentityHubClient implements DidDocumentServiceClient {
+
+    static final MediaType JSON = MediaType.parse("application/json");
+
+    private final EdcHttpClient httpClient;
+    private final String identityApiUrl;
+    private final String participantId;
+    private final String ownDid;
+    private final String apiKey;
+    private final Monitor monitor;
+
+    public DidDocumentServiceIdentityHubClient(EdcHttpClient httpClient,
+                                               String identityApiUrl,
+                                               String participantId,
+                                               String ownDid,
+                                               String apiKey,
+                                               Monitor monitor) {
+        this.httpClient = httpClient;
+        this.identityApiUrl = identityApiUrl;
+        this.participantId = participantId;
+        this.ownDid = ownDid;
+        this.apiKey = apiKey;
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+    }
+
+    @Override
+    public ServiceResult<Void> update(Service service) {
+        // IdentityHub handles upsert: delete existing (ignore 404) then create
+        return deleteServiceEntry(service.getId())
+                .compose(v -> createServiceEntry(service))
+                .onSuccess(v -> monitor.info("Updated service entry '%s' (type=%s) in DID Document via IdentityHub"
+                        .formatted(service.getId(), service.getType())))
+                .onFailure(f -> monitor.warning("Failed to update service entry '%s': %s"
+                        .formatted(service.getId(), f.getFailureDetail())));
+    }
+
+    @Override
+    public ServiceResult<Void> deleteById(String id) {
+        return deleteServiceEntry(id)
+                .onSuccess(v -> monitor.info("Deleted service entry '%s' from DID Document via IdentityHub".formatted(id)))
+                .onFailure(f -> monitor.severe("Failed to delete service entry '%s': %s".formatted(id, f.getFailureDetail())));
+    }
+
+    private ServiceResult<Void> createServiceEntry(Service service) {
+        var json = "{\"id\":\"%s\",\"type\":\"%s\",\"serviceEndpoint\":\"%s\"}"
+                .formatted(service.getId(), service.getType(), service.getServiceEndpoint());
+
+        var request = new Request.Builder()
+                .url(endpointsUrl() + "?autoPublish=true")
+                .post(RequestBody.create(json, JSON))
+                .addHeader("x-api-key", apiKey)
+                .addHeader("Content-Type", "application/json")
+                .build();
+
+        return executeRequest(request, "create", 409);
+    }
+
+    private ServiceResult<Void> deleteServiceEntry(String serviceId) {
+        var request = new Request.Builder()
+                .url(endpointsUrl() + "/" + serviceId + "?autoPublish=true")
+                .delete()
+                .addHeader("x-api-key", apiKey)
+                .build();
+
+        return executeRequest(request, "delete", 404);
+    }
+
+    /**
+     * Constructs the base URL for the IdentityHub endpoints API.
+     * Path: {@code {identityApiUrl}/v1alpha/participants/{participantB64}/dids/{didB64}/endpoints}
+     */
+    private String endpointsUrl() {
+        var participantB64 = base64Encode(participantId);
+        var didB64 = base64Encode(ownDid);
+        return "%s/v1alpha/participants/%s/dids/%s/endpoints".formatted(identityApiUrl, participantB64, didB64);
+    }
+
+    /**
+     * Execute an HTTP request against the IdentityHub identity API.
+     *
+     * @param request         the OkHttp request
+     * @param operation       label for logging
+     * @param toleratedStatus additional status code to treat as success (e.g. 404 for delete, 409 for create)
+     */
+    private ServiceResult<Void> executeRequest(Request request, String operation, int toleratedStatus) {
+        try (var response = httpClient.execute(request, List.of())) {
+            if (response.isSuccessful()) {
+                return ServiceResult.success();
+            }
+            if (response.code() == toleratedStatus) {
+                monitor.debug("%s returned %d — treating as success (idempotent)".formatted(operation, toleratedStatus));
+                return ServiceResult.success();
+            }
+            return handleResponse(response, operation);
+        } catch (IOException e) {
+            return ServiceResult.unexpected("IdentityHub %s request failed: %s".formatted(operation, e.getMessage()));
+        }
+    }
+
+    ServiceResult<Void> handleResponse(Response response, String operation) {
+        if (response.isSuccessful()) {
+            return ServiceResult.success();
+        }
+        var body = "";
+        try {
+            if (response.body() != null) {
+                body = response.body().string();
+            }
+        } catch (IOException e) {
+            monitor.warning("Failed to read response body for %s".formatted(operation), e);
+        }
+        return ServiceResult.unexpected("IdentityHub %s failed with status %d: %s"
+                .formatted(operation, response.code(), body));
+    }
+
+    static String base64Encode(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes());
+    }
+}

--- a/edc-extensions/did-document/did-document-service-identityhub/src/main/java/org/eclipse/tractusx/edc/did/document/service/identityhub/DidDocumentServiceIdentityHubClientExtension.java
+++ b/edc-extensions/did-document/did-document-service-identityhub/src/main/java/org/eclipse/tractusx/edc/did/document/service/identityhub/DidDocumentServiceIdentityHubClientExtension.java
@@ -1,0 +1,93 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.did.document.service.identityhub;
+
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provides;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.tractusx.edc.spi.did.document.service.DidDocumentServiceClient;
+
+/**
+ * Extension that registers a {@link DidDocumentServiceClient} backed by the
+ * IdentityHub identity API, enabling DID Document self-registration for
+ * deployments that use IdentityHub as their wallet (instead of SAP DIM).
+ * <p>
+ * This extension activates only when {@code tx.edc.ih.api.url} is configured.
+ * If missing, it logs a message and skips registration, allowing the DIM-based
+ * client to take over (or no client at all).
+ */
+@Provides(DidDocumentServiceClient.class)
+public class DidDocumentServiceIdentityHubClientExtension implements ServiceExtension {
+
+    public static final String TX_EDC_IH_API_URL = "tx.edc.ih.api.url";
+    public static final String TX_EDC_IH_API_KEY = "tx.edc.ih.api.key";
+    public static final String TX_EDC_IH_PARTICIPANT_CONTEXT_ID = "tx.edc.ih.participant.context.id";
+
+    @Inject
+    private EdcHttpClient httpClient;
+
+    @Inject
+    private Monitor monitor;
+
+    @Setting(key = TX_EDC_IH_API_URL, description = "IdentityHub identity API base URL (e.g. http://provider-ih:15151/api/identity)", required = false)
+    private String identityHubApiUrl;
+
+    @Setting(key = TX_EDC_IH_API_KEY, description = "API key for IdentityHub identity API", required = false)
+    private String identityHubApiKey;
+
+    @Setting(key = TX_EDC_IH_PARTICIPANT_CONTEXT_ID, description = "IdentityHub participant context ID (short name, e.g. 'provider')", required = false)
+    private String participantContextId;
+
+    @Setting(key = "edc.iam.issuer.id", description = "The DID of this connector's participant")
+    private String ownDid;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        if (identityHubApiUrl == null || identityHubApiUrl.isBlank()) {
+            monitor.info("IdentityHub DID Document Service client will not be registered: %s is not configured".formatted(TX_EDC_IH_API_URL));
+            return;
+        }
+
+        if (identityHubApiKey == null || identityHubApiKey.isBlank()) {
+            monitor.warning("IdentityHub DID Document Service client will not be registered: %s is not configured".formatted(TX_EDC_IH_API_KEY));
+            return;
+        }
+
+        if (participantContextId == null || participantContextId.isBlank()) {
+            monitor.warning("IdentityHub DID Document Service client will not be registered: %s is not configured".formatted(TX_EDC_IH_PARTICIPANT_CONTEXT_ID));
+            return;
+        }
+
+        var client = new DidDocumentServiceIdentityHubClient(
+                httpClient,
+                identityHubApiUrl,
+                participantContextId,
+                ownDid,
+                identityHubApiKey,
+                monitor);
+
+        context.registerService(DidDocumentServiceClient.class, client);
+        monitor.info("Registered IdentityHub-based DidDocumentServiceClient (API: %s, DID: %s)".formatted(identityHubApiUrl, ownDid));
+    }
+}

--- a/edc-extensions/did-document/did-document-service-identityhub/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/edc-extensions/did-document/did-document-service-identityhub/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,20 @@
+#################################################################################
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+org.eclipse.tractusx.edc.did.document.service.identityhub.DidDocumentServiceIdentityHubClientExtension

--- a/edc-extensions/did-document/did-document-service-identityhub/src/test/java/org/eclipse/tractusx/edc/did/document/service/identityhub/DidDocumentServiceIdentityHubClientTest.java
+++ b/edc-extensions/did-document/did-document-service-identityhub/src/test/java/org/eclipse/tractusx/edc/did/document/service/identityhub/DidDocumentServiceIdentityHubClientTest.java
@@ -1,0 +1,192 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.did.document.service.identityhub;
+
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.iam.did.spi.document.Service;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DidDocumentServiceIdentityHubClientTest {
+
+    private static final String IDENTITY_API_URL = "http://provider-ih:15151/api/identity";
+    private static final String PARTICIPANT_ID = "did:web:provider-ih:provider";
+    private static final String OWN_DID = "did:web:provider-ih:provider";
+    private static final String API_KEY = "c3VwZXItdXNlcg==.superuserkey";
+    private static final String SERVICE_ID = "dsp-endpoint";
+    private static final String SERVICE_TYPE = "DataService";
+    private static final String SERVICE_ENDPOINT = "http://provider-cp:8084/api/v1/dsp/.well-known/dspace-version";
+
+    private final EdcHttpClient httpClient = mock(EdcHttpClient.class);
+    private final Monitor monitor = mock(Monitor.class);
+
+    private DidDocumentServiceIdentityHubClient client;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        when(monitor.withPrefix(anyString())).thenReturn(monitor);
+        client = new DidDocumentServiceIdentityHubClient(
+                httpClient, IDENTITY_API_URL, PARTICIPANT_ID, OWN_DID, API_KEY, monitor);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void update_shouldDeleteThenCreate() throws IOException {
+        when(httpClient.execute(any(Request.class), any(List.class)))
+                .thenReturn(response(404))   // delete: not found
+                .thenReturn(response(204));   // create: success
+
+        var service = new Service(SERVICE_ID, SERVICE_TYPE, SERVICE_ENDPOINT);
+        var result = client.update(service);
+
+        assertThat(result).isSucceeded();
+
+        var captor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient, times(2)).execute(captor.capture(), any(List.class));
+
+        var requests = captor.getAllValues();
+
+        // First request: DELETE
+        assertThat(requests.get(0).method()).isEqualTo("DELETE");
+        assertThat(requests.get(0).url().toString()).contains("/endpoints/" + SERVICE_ID);
+        assertThat(requests.get(0).header("x-api-key")).isEqualTo(API_KEY);
+
+        // Second request: POST
+        assertThat(requests.get(1).method()).isEqualTo("POST");
+        assertThat(requests.get(1).url().toString()).contains("/endpoints?autoPublish=true");
+        assertThat(requests.get(1).header("x-api-key")).isEqualTo(API_KEY);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void update_shouldEncodeParticipantAndDidInBase64() throws IOException {
+        when(httpClient.execute(any(Request.class), any(List.class)))
+                .thenReturn(response(404))
+                .thenReturn(response(204));
+
+        var service = new Service(SERVICE_ID, SERVICE_TYPE, SERVICE_ENDPOINT);
+        client.update(service);
+
+        var captor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient, times(2)).execute(captor.capture(), any(List.class));
+
+        var expectedParticipantB64 = Base64.getEncoder().encodeToString(PARTICIPANT_ID.getBytes());
+        var expectedDidB64 = Base64.getEncoder().encodeToString(OWN_DID.getBytes());
+
+        var url = captor.getAllValues().get(1).url().toString();
+        assertThat(url).contains("/participants/" + expectedParticipantB64 + "/dids/" + expectedDidB64 + "/endpoints");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void update_shouldFailWhenCreateFails() throws IOException {
+        when(httpClient.execute(any(Request.class), any(List.class)))
+                .thenReturn(response(404))    // delete: not found (tolerated)
+                .thenReturn(response(500));    // create: server error
+
+        var service = new Service(SERVICE_ID, SERVICE_TYPE, SERVICE_ENDPOINT);
+        var result = client.update(service);
+
+        assertThat(result).isFailed();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void update_shouldSucceedWhenCreateReturns409() throws IOException {
+        when(httpClient.execute(any(Request.class), any(List.class)))
+                .thenReturn(response(204))    // delete: success
+                .thenReturn(response(409));   // create: conflict (tolerated — idempotent)
+
+        var service = new Service(SERVICE_ID, SERVICE_TYPE, SERVICE_ENDPOINT);
+        var result = client.update(service);
+
+        assertThat(result).isSucceeded();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void deleteById_shouldCallDeleteEndpoint() throws IOException {
+        when(httpClient.execute(any(Request.class), any(List.class)))
+                .thenReturn(response(204));
+
+        var result = client.deleteById(SERVICE_ID);
+
+        assertThat(result).isSucceeded();
+
+        var captor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient).execute(captor.capture(), any(List.class));
+
+        assertThat(captor.getValue().method()).isEqualTo("DELETE");
+        assertThat(captor.getValue().url().toString()).contains("/endpoints/" + SERVICE_ID + "?autoPublish=true");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void deleteById_shouldSucceedWhenNotFound() throws IOException {
+        when(httpClient.execute(any(Request.class), any(List.class)))
+                .thenReturn(response(404));
+
+        var result = client.deleteById(SERVICE_ID);
+
+        assertThat(result).isSucceeded();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void update_shouldFailWhenHttpClientThrows() throws IOException {
+        when(httpClient.execute(any(Request.class), any(List.class)))
+                .thenThrow(new IOException("Connection refused"));
+
+        var service = new Service(SERVICE_ID, SERVICE_TYPE, SERVICE_ENDPOINT);
+        var result = client.update(service);
+
+        assertThat(result).isFailed();
+    }
+
+    private static Response response(int code) {
+        return new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(code)
+                .message("OK")
+                .body(ResponseBody.create("", null))
+                .build();
+    }
+}

--- a/edc-extensions/did-document/did-document-service-identityhub/src/test/java/org/eclipse/tractusx/edc/did/document/service/identityhub/DidDocumentServiceIdentityHubClientTest.java
+++ b/edc-extensions/did-document/did-document-service-identityhub/src/test/java/org/eclipse/tractusx/edc/did/document/service/identityhub/DidDocumentServiceIdentityHubClientTest.java
@@ -19,29 +19,29 @@
 
 package org.eclipse.tractusx.edc.did.document.service.identityhub;
 
-import okhttp3.Protocol;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import org.eclipse.edc.http.spi.EdcHttpClient;
-import org.eclipse.edc.iam.did.spi.document.Service;
-import org.eclipse.edc.spi.monitor.Monitor;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-
 import java.io.IOException;
 import java.util.Base64;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.iam.did.spi.document.Service;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 class DidDocumentServiceIdentityHubClientTest {
 

--- a/edc-extensions/did-document/did-document-service-self-registration/README.md
+++ b/edc-extensions/did-document/did-document-service-self-registration/README.md
@@ -35,6 +35,17 @@ The extension is controlled by the following configuration properties:
 - **On Shutdown:**
   - The extension automatically deletes the registered service entry from the DID Document.
 
+## Available Implementations
+
+This extension requires a `DidDocumentServiceClient` implementation to interact with the wallet. The following implementations are available:
+
+| Module | Wallet | Description |
+|--------|--------|-------------|
+| [`did-document-service-identityhub`](../did-document-service-identityhub) | Eclipse Tractus-X IdentityHub | REST-based client using the IdentityHub Identity API (POST/DELETE endpoints). Suitable for local, dev, and open-source wallet deployments. |
+| [`did-document-service-dim`](../did-document-service-dim) | SAP DIM | PATCH-based client for SAP Decentralized Identity Management wallets. Suitable for SAP-managed production environments. |
+
+Include exactly one implementation module in your control plane build alongside this extension.
+
 ## Disable the Extension
 - Set the property `tx.edc.did.service.self.registration.enabled=false` in your configuration to disable this feature.
 - Do not include any extension which provides the implementation of SPI `DidDocumentServiceClient` to update the DID Document.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -96,6 +96,7 @@ include(":edc-extensions:dataspace-protocol:cx-dataspace-protocol")
 include(":edc-extensions:dataspace-protocol:dataspace-protocol-core")
 include(":edc-extensions:did-document:did-document-service-self-registration")
 include(":edc-extensions:did-document:did-document-service-dim")
+include(":edc-extensions:did-document:did-document-service-identityhub")
 
 include(":edc-extensions:agreements")
 include(":edc-extensions:agreements:retirement-evaluation-core")


### PR DESCRIPTION
## Description

Implements a new `DidDocumentServiceClient` backed by **IdentityHub's Identity API**, enabling EDC connectors to self-register their DID Document service endpoints (e.g., `DataService`) at startup — without requiring the external DIM (Decentralized Identity Management) service used in production Catena-X environments.

This is the missing SPI implementation needed for the existing `did-document-service-self-registration` extension to work with per-company IdentityHub wallets in local/dev DCP deployments.

## Motivation

The self-registration extension (`did-document-service-self-registration`) was designed to automatically register a connector's DSP endpoint as a `DataService` entry in its DID Document on startup. However, the only existing `DidDocumentServiceClient` implementation (`did-document-service-dim`) requires a DIM OAuth2 service — unavailable in local deployments. This left a gap where bootstrap scripts had to manually inject `DataService` endpoints via direct DB manipulation.

This PR closes that gap by providing a lightweight HTTP client that talks directly to IdentityHub's Identity API (`/v1alpha/participants/{id}/dids/{did}/endpoints`).

## Changes

### New Module
- **`edc-extensions/did-document/did-document-service-identityhub/`** — New extension providing `DidDocumentServiceClient` via IdentityHub Identity API
  - `DidDocumentServiceIdentityHubClient` — HTTP client implementing create/update/delete operations
  - `DidDocumentServiceIdentityHubClientExtension` — EDC extension with conditional activation (requires `tx.edc.ih.api.url`)
  - 7 unit tests covering all operations, error handling, and 409 conflict tolerance
  - README with configuration reference

### Configuration Properties
| Property | Description |
|---|---|
| `tx.edc.ih.api.url` | IdentityHub Identity API base URL (activates extension) |
| `tx.edc.ih.api.key` | API key for IdentityHub super-user authentication |
| `tx.edc.ih.participant.context.id` | Participant context ID in IdentityHub |

### Helm Charts (both `tractusx-connector` and `tractusx-connector-memory`)
- Added `iatp.didService.identityHub` values (apiUrl, apiKey, participantContextId)
- Added conditional env var injection in deployment templates

### Bootstrap Script Fixes
- **Step 7**: Fixed `jsonb_set()` calls on `json`-typed `did_document` column (added `::jsonb`/`::json` casts, narrowed WHERE clauses)
- **Step 8**: Same `json`→`jsonb` cast fix for issuer DID service endpoint
- **Step 10**: Fixed credential request field names (`type` + `id` instead of `credentialType`); retrieve credential definition UUIDs from DB since POST returns empty body

### Documentation
- Updated 6 existing docs with self-registration and IH client information
- Created new README for the `did-document-service-identityhub` module

## How It Works
Connector startup
→ Self-Registration Extension fires start()
→ Injects DidDocumentServiceClient (IH client)
→ DELETE /v1alpha/participants/{ctx}/dids/{did}/endpoints/{id} (idempotent)
→ POST /v1alpha/participants/{ctx}/dids/{did}/endpoints?autoPublish=true
→ DataService entry appears in DID Document ✓


The DIM and IH clients are **mutually exclusive** at runtime:
- DIM activates when `tx.edc.iam.sts.dim.url` is configured + `DimOauth2Client` is injected
- IH activates when `tx.edc.ih.api.url` is configured
- If neither is configured, self-registration gracefully does nothing

## Testing

- **Unit tests**: 7/7 pass — covers create, update (delete+create), delete, error handling, 409 conflict tolerance
- **Bootstrap**: All 16 steps pass — 3/3 credentials issued per participant, catalog/negotiation/transfer succeed
- **Newman E2E**: 67 requests, 65 assertions, 0 failures
- **Self-registration on restart**: Both provider-cp and consumer-cp log "Self Registration of DID Document service successful"

## Commits

1. `450f89fc4` — `feat(did): add IdentityHub-based DidDocumentServiceClient for DID self-registration`
2. `fde587683` — `docs: update documentation for IdentityHub-based DID self-registration`
3. `a72df3a15` — `feat(helm): add IdentityHub client settings for DID self-registration`
4. `c7d22ae38` — `fix(bootstrap): fix json/jsonb casts and credential request field names`

## Files Changed

20 files changed, 764 insertions(+), 23 deletions(-)